### PR TITLE
Push the just announced panel down by 24px

### DIFF
--- a/app/src/assets/scss/_ohw.scss
+++ b/app/src/assets/scss/_ohw.scss
@@ -25,6 +25,12 @@
   font-weight: bold !important;
   background-color: $bright !important;
 }
+/* The just announced block is hidden by the new header - this is a temporary fix */
+@media(min-width: 992px){
+    .badge-success {
+        margin-top: 24px;
+    }
+}
 
 .btn-primary {
   font-family: 'Lato', sans-serif;


### PR DESCRIPTION
(and the rest of the header) - fixes issues with desktop rendering of the site hiding most of the just announced banner in FF and Chrome