### PR TITLE
Typewriter effect

### DIFF
--- a/app/src/assets/js/app.js
+++ b/app/src/assets/js/app.js
@@ -26,7 +26,9 @@ require('./scripts');
 
 require('./libs/animated-headline');
 
-require('./components/super-nav')
+require('./components/super-nav');
+
+require('./components/typewrighter');
 
 require('./components/_lightSlider');
 

--- a/app/src/assets/js/components/typewrighter.js
+++ b/app/src/assets/js/components/typewrighter.js
@@ -1,0 +1,17 @@
+var allWhite = RegExp.prototype.test.bind(/^\s/);
+
+$(function(){
+  var typewriter = $('.typewriter')[0]
+  
+  typewriter.innerHTML = typewriter.textContent
+    .split('')
+    .reduce(function(a, b){
+      return allWhite(a) && allWhite(b) ? a : a + b
+    })
+    .split('')
+    .map(function(character, index, total){
+      return index == 0 || index == total.length ? '' : '<span class=glyph>' + character + '</span>'
+    })
+    .join('')
+    
+});

--- a/app/src/assets/scss/components/_lightSlider.scss
+++ b/app/src/assets/scss/components/_lightSlider.scss
@@ -79,35 +79,46 @@
   }
 }
 
-.lslide.active {
-  @include desktop {
-    .typewriter {
-      overflow: hidden; /* Ensures the content is not revealed until the animation */
-      border-right: .15em solid rgba(0, 0, 0, 0.5); /* The typwriter cursor */
-      white-space: nowrap; /* Keeps the content on a single line */
-      margin: 0 auto; /* Gives that scrolling effect as the typing happens */
-      animation: typing 3.5s steps(40, end),
-      blink-caret .75s step-end infinite;
-    }
+.typewrapper {
+  display: inline-block;
+}
 
-    /* The typing effect */
-    @keyframes typing {
-      from {
-        width: 0
-      }
-      to {
-        width: 100%
-      }
-    }
+.typewriter {
+  overflow: hidden; /* Ensures the content is not revealed until the animation */
+  border-right: .15em solid rgba(0, 0, 0, 0.5); /* The typwriter cursor */
+  display: inline-block;
+  white-space: nowrap; /* Keeps the content on a single line */
+  margin: 0 auto; /* Gives that scrolling effect as the typing happens */
 
-    /* The typewriter cursor effect */
-    @keyframes blink-caret {
-      from, to {
-        border-color: transparent
-      }
-      50% {
-        border-color: rgba(0, 0, 0, 0.4);
-      }
-    }
+  .glyph {
+    display: inline-block;
+    text-align: center;
+    width: 1ex;
+  }
+}
+
+.typewriter.animated {
+  animation: 
+    typing 3.5s steps(15),
+    blink-caret .75s step-end infinite;
+}
+
+/* The typing effect */
+@keyframes typing {
+  from {
+    width: 0
+  }
+  to {
+    width: 100%
+  }
+}
+
+/* The typewriter cursor effect */
+@keyframes blink-caret {
+  from, to {
+    border-color: transparent
+  }
+  50% {
+    border-color: white;
   }
 }

--- a/app/src/index.html
+++ b/app/src/index.html
@@ -13,8 +13,10 @@
           </span>
         </div>
 
-        <h1 class="s-128 bolder text-white fadeInUpShort animated go delay-250">
-          {nhs.ideas.lab}
+        <h1 class="typewrapper s-128 bolder text-white go delay-250">
+          <span class="typewriter animated">
+            {nhs.ideas.lab}
+          </span>
         </h1>
 
         <h3 class="fadeInUpShort animated go">


### PR DESCRIPTION
Fixes #83, I think. Don't know how the original effect was applied so I assumed mess with the title only.

Made the cursor the same colour as the text, ditched the old animation which moved forward a pre-determined fraction of overall width every frame (instead of revealing precisely one character), also introduced a randomised delay between each strike to make it look more like actual typing.

![typewriter](https://user-images.githubusercontent.com/83627/32282102-978e4fb0-bf18-11e7-880e-862e4945be51.gif)
